### PR TITLE
Fix getting settings file path

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,7 +1,8 @@
 module.exports = (() => {
   var path = require('path');
+  var os = require('os');
 
-  const home_directory = process.cwd();
+  const home_directory = os.homedir();
   const config = {
     directory_name: '.jira-cli',
     config_file_name: 'config.json',


### PR DESCRIPTION
jira-cli couldn't find it's own settings file if it was run from a directory other than home, this fixes the issue and enables it to run from any directory.